### PR TITLE
fix AddSuiteTest and AddTestCaseTest

### DIFF
--- a/src/main/java/org/academy/ui/pages/AddSuitePage.java
+++ b/src/main/java/org/academy/ui/pages/AddSuitePage.java
@@ -1,6 +1,7 @@
 package org.academy.ui.pages;
 
 import org.openqa.selenium.By;
+import org.openqa.selenium.interactions.Actions;
 
 public class AddSuitePage extends AbstractPage {
     public AddSuitePage() {
@@ -16,11 +17,17 @@ public class AddSuitePage extends AbstractPage {
     private static final By acceptBtn = By.xpath("//span[@class='editSectionAdd']");
     private static final By testCasesLink = By.xpath("//a[@id='navigation-suites']");
     private static final By addSectionBtn = By.xpath("//a[@id='addSectionInline']");
+    private static final By addSectionLink = By.xpath("//a[@id='addSection']");
+    private static final By deleteBtn = By.xpath("//div[@class='icon-small-delete hidden action-hover']");
+    private static final By okBtn = By.xpath("//div[@id='deleteDialog']//div[@class='button-group dialog-buttons-highlighted']//a[@class='button button-ok button-left button-positive dialog-action-default'][contains(text(),'OK')]");
+    private static final By sectionTitle = By.xpath("//div[@class='grid-title']");
+    private static final By confirmDeleteCheckBox = By.xpath("//div[@id='deleteDialog']//div[@class='dialog-body']//div[@class='message message-delete bottom delete-confirm-container']//div[@class='checkbox']//label//input[@type='checkbox']");
 
     public AddSuitePage clickOnTestCasesLink() {
         waitUntilElementIsClickable(testCasesLink).click();
         return this;
     }
+
     public AddSuitePage clickOnAddSectionBtn() {
         waitUntilElementIsClickable(addSectionBtn).click();
         return this;
@@ -40,5 +47,34 @@ public class AddSuitePage extends AbstractPage {
     public AddSuitePage clickOnAcceptBtn() {
         waitUntilElementIsClickable(acceptBtn).click();
         return this;
+    }
+
+    public AddSuitePage clickOnAddSectionLink() {
+        waitUntilElementIsClickable(addSectionLink).click();
+        return this;
+    }
+
+    public AddSuitePage clickOnDeleteBtn() {
+        waitUntilElementIsClickable(deleteBtn).click();
+        return this;
+    }
+
+    public AddSuitePage clickOnOkBtn() {
+        waitUntilElementIsClickable(okBtn).click();
+        return this;
+    }
+
+    public void placeCursorOverElement() {
+        Actions builder = new Actions(webDriver);
+        builder.moveToElement(webDriver.findElement(sectionTitle)).perform();
+    }
+
+    public AddSuitePage clickOnConfirmDeleteCheckBox() {
+        waitUntilElementIsClickable(confirmDeleteCheckBox).click();
+        return this;
+    }
+
+    public By getSectionTitle() {
+        return sectionTitle;
     }
 }

--- a/src/main/java/org/academy/ui/pages/AddTestCasePage.java
+++ b/src/main/java/org/academy/ui/pages/AddTestCasePage.java
@@ -1,6 +1,7 @@
 package org.academy.ui.pages;
 
 import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
 
 public class AddTestCasePage extends AbstractPage {
     public AddTestCasePage() {
@@ -11,10 +12,10 @@ public class AddTestCasePage extends AbstractPage {
         super(navigate, navigateToUrl);
     }
 
-    private static final By titleField = By.xpath("//form[@class='inline form-inline addForm']//input[@type='text']");
-    private static final By acceptBtn = By.xpath("//span[@class='buttons']//button[@type='submit']");
+    private static final By titleField = By.xpath("//input[@id='title']");
+    private static final By acceptBtn = By.xpath("//button[@id='accept']");
     private static final By testCaseLink = By.xpath("//a[@id='navigation-suites']");
-    private static final By addTestCaseBtn = By.xpath("//a[contains(text(),'Add Case')]");
+    private static final By addTestCaseBtn = By.xpath("//a[@id='sidebar-cases-add']");
 
     public AddTestCasePage clickOnTestCaseLink() {
         waitUntilElementIsClickable(testCaseLink).click();
@@ -33,5 +34,9 @@ public class AddTestCasePage extends AbstractPage {
     public AddTestCasePage clickOnAcceptBtn() {
         waitUntilElementIsClickable(acceptBtn).click();
         return this;
+    }
+
+    public WebElement getAcceptBtn() {
+        return webDriver.findElement(acceptBtn);
     }
 }

--- a/src/main/java/org/academy/ui/pages/MainPage.java
+++ b/src/main/java/org/academy/ui/pages/MainPage.java
@@ -16,7 +16,7 @@ public class MainPage extends AbstractPage {
     private static final By logout = By.xpath("//a[@id='navigation-user-logout']");
     private static final By addProjectBtn = By.xpath("//a[@id='sidebar-projects-add']");
     private static final By administrationLink = By.xpath("//a[@id='navigation-admin']");
-    private static final By projectLink = By.xpath("//div[@id='project-7']//div[@class='column summary-column flex-projects-2']//div[@class='summary-title text-ppp']//a[contains(text(),'TestProject')]");
+    private static final By projectLink = By.xpath("//div[@class='summary-title text-ppp']//a[contains(text(),'TestProject')]");
 
     public MainPage clickOnMyUsername() {
         waitUntilElementIsClickable(usernameLink).click();

--- a/src/test/java/org/academy/ui/AddSuiteTest.java
+++ b/src/test/java/org/academy/ui/AddSuiteTest.java
@@ -3,7 +3,6 @@ package org.academy.ui;
 import org.academy.ui.pages.AddSuitePage;
 import org.academy.ui.pages.MainPage;
 import org.academy.ui.steps.LoginSteps;
-import org.openqa.selenium.By;
 import org.slf4j.Logger;
 import org.testng.annotations.AfterSuite;
 import org.testng.annotations.BeforeMethod;
@@ -12,7 +11,7 @@ import org.testng.annotations.Test;
 import static java.lang.invoke.MethodHandles.lookup;
 import static org.slf4j.LoggerFactory.getLogger;
 
-public class AddSuiteTest extends BaseTest{
+public class AddSuiteTest extends BaseTest {
 
     static final Logger log = getLogger(lookup().lookupClass());
     private LoginSteps loginSteps = new LoginSteps();
@@ -33,10 +32,26 @@ public class AddSuiteTest extends BaseTest{
     @Test
     public void addSuiteTest() throws InterruptedException {
         AddSuitePage addSuitePage = mainPage.clickOnProjectLink()
-                .clickOnTestCasesLink()
-                .clickOnAddSectionBtn()
-                .fillNameField("Test Section")
-                .fillDescriptionField("Test Description");
-        addSuitePage.clickOnAcceptBtn();
+                .clickOnTestCasesLink();
+        try {
+            addSuitePage.clickOnAddSectionBtn()
+                    .fillNameField("Test Section")
+                    .fillDescriptionField("Test Description");
+            addSuitePage.clickOnAcceptBtn();
+
+        } catch (RuntimeException e) {
+            addSuitePage.clickOnAddSectionLink()
+                    .fillNameField("Test Section")
+                    .fillDescriptionField("Test Description");
+            addSuitePage.clickOnAcceptBtn();
+            addSuitePage.refreshPage();
+        } finally {
+            addSuitePage.waitUntilElementIsClickable(addSuitePage.getSectionTitle());
+            addSuitePage.placeCursorOverElement();
+            addSuitePage
+                    .clickOnDeleteBtn()
+                    .clickOnConfirmDeleteCheckBox()
+                    .clickOnOkBtn();
+        }
     }
 }

--- a/src/test/java/org/academy/ui/AddTestCaseTest.java
+++ b/src/test/java/org/academy/ui/AddTestCaseTest.java
@@ -3,7 +3,6 @@ package org.academy.ui;
 import org.academy.ui.pages.AddTestCasePage;
 import org.academy.ui.pages.MainPage;
 import org.academy.ui.steps.LoginSteps;
-import org.openqa.selenium.By;
 import org.testng.annotations.AfterSuite;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
@@ -28,9 +27,12 @@ public class AddTestCaseTest extends BaseTest {
     @Test
     public void addTestCaseTest() throws InterruptedException {
         AddTestCasePage addTestCasePage = mainPage.clickOnProject()
-                .clickOnTestCaseLink()
-                .clickOnAddTestCaseBtn()
-                .fillTitleField("Test case Test");
-        addTestCasePage.clickOnAcceptBtn();
+                .clickOnTestCaseLink();
+            addTestCasePage
+                    .clickOnAddTestCaseBtn()
+                    .fillTitleField("Test case Test");
+            addTestCasePage.scrollToElement(webDriver, addTestCasePage.getAcceptBtn());
+            addTestCasePage
+                    .clickOnAcceptBtn();
     }
 }


### PR DESCRIPTION
Tests were crashing because after first suite or test case creation, page layout would have changed and links used by tests would become unavailable for test to run successfully. So tests are rebuilt to utilize links that are always present on the web-page.
Also section deletion was added at the end of the test to perform clean-up.